### PR TITLE
Fix: Break reference cycle causing memory leaks.

### DIFF
--- a/src/main/native/enum_members.cpp
+++ b/src/main/native/enum_members.cpp
@@ -19,13 +19,6 @@
 using namespace smjni;
 using namespace dcsctp;
 
-template <typename E> global_java_ref<E> enum_field(JNIEnv* env, java_class<E> clazz, const char* name)
-{
-    java_static_field<E, E> field(env, clazz, name);
-    return field.get(env, clazz);
-}
-
-
 DelayPrecision_members::DelayPrecision_members(JNIEnv * env) :
     m_kLow(java_classes::get<DcSctpSocketCallbacks_DelayPrecision_class>().get_kLow(env)),
     m_kHigh(java_classes::get<DcSctpSocketCallbacks_DelayPrecision_class>().get_kHigh(env))

--- a/src/main/native/native_sctp_socket.cpp
+++ b/src/main/native/native_sctp_socket.cpp
@@ -29,6 +29,13 @@ NativeSctpSocket::NativeSctpSocket(jDcSctpSocketCallbacks jCallbacks) :
 {
 }
 
+void JNICALL DcSctpSocketFactory_NativeSctpSocket_class::destruct(JNIEnv *env, jclass, jlong ptr)
+{
+NATIVE_PROLOG
+    auto nativeSocket = (NativeSctpSocket*)(intptr_t)ptr;
+    delete nativeSocket;
+NATIVE_EPILOG
+}
 
 void JNICALL DcSctpSocketFactory_NativeSctpSocket_class::receivePacket_(JNIEnv* env, jDcSctpSocketFactory_NativeSctpSocket, jlong ptr, jbyteArray data, jint offset, jint length)
 {

--- a/src/main/native/wrapped_objects.cpp
+++ b/src/main/native/wrapped_objects.cpp
@@ -109,7 +109,7 @@ local_java_ref<jDcSctpSocketCallbacks> WrappedSocketCallbacks::getObj(JNIEnv *en
     local_java_ref<jDcSctpSocketCallbacks> obj(wSocketCallbacks);
 
     if (!obj) {
-        auto ex = java_runtime::throwable().ctor(env, java_string_create(env, "Weak PacketObserver reference garbage collected"));
+        auto ex = java_runtime::throwable().ctor(env, java_string_create(env, "Weak DcSctpSocketCallbacks reference garbage collected"));
         throw java_exception(ex);
     }
     return obj;

--- a/src/main/native/wrapped_objects.h
+++ b/src/main/native/wrapped_objects.h
@@ -70,7 +70,9 @@ class WrappedSocketCallbacks: public dcsctp::DcSctpSocketCallbacks {
     
   private:
     DcSctpSocketCallbacks_class socketCallbacksClass;
-    smjni::global_java_ref<jDcSctpSocketCallbacks> socketCallbacks;
+    smjni::weak_java_ref<jDcSctpSocketCallbacks> wSocketCallbacks;
+
+    smjni::local_java_ref<jDcSctpSocketCallbacks> getObj(JNIEnv* env);
 };
 
 class WrappedPacketObserver: public dcsctp::PacketObserver {
@@ -82,7 +84,9 @@ class WrappedPacketObserver: public dcsctp::PacketObserver {
 
   private:
     PacketObserver_class packetObserverClass;
-    smjni::global_java_ref<jPacketObserver> javaObserver;
+    smjni::weak_java_ref<jPacketObserver> wJavaObserver;
+
+    smjni::local_java_ref<jPacketObserver> getObj(JNIEnv* env);
 };
 
 class WrappedTimeout: public dcsctp::Timeout {


### PR DESCRIPTION
Keep references to a socket's SocketCallabcks (and PacketObserver if present) in Java, and only hold weak references to them from JNI.  This lets the Java GC see reference cycles, so it can free objects properly.