### PR TITLE
Add ppc64le cross-compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Prerequisites:
 - Maven
 - CMake
 - Git
-- APT packages `build-essentials`, `g++-aarch64-linux-gnu` and their dependencies
+- APT packages `build-essentials`, `g++-aarch64-linux-gnu`, `g++-powerpc64le-linux-gnu`, and their dependencies
 
 * Clone the project
 * Update the SimpleJNI subproject with

--- a/cmake/ppc64le-linux-gnu.cmake
+++ b/cmake/ppc64le-linux-gnu.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_PROCESSOR "ppc64le")
+
+set(CMAKE_C_COMPILER /usr/bin/powerpc64le-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/powerpc64le-linux-gnu-g++)

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -1,0 +1,100 @@
+# Minimal build steps that produce libdcsctp.a
+# Copyright (C) 2025
+# Author: Thomas Fitzsimmons <fitzsim@fitzsim.org>
+# Version: 1
+# SPDX-License-Identifier: Apache-2.0
+CXXFLAGS = -fPIC -DWEBRTC_POSIX -Wno-return-type
+CXXFLAGS += -I../..
+CXXFLAGS += -I../../third_party/abseil-cpp
+CXXFLAGS += -I../../third_party/crc32c/src/include
+CXXFLAGS += -I../../third_party/crc32c/config
+OBJS = \
+	../../rtc_base/logging.o \
+	../../rtc_base/strings/string_format.o \
+	../../rtc_base/strings/string_builder.o \
+	../../rtc_base/string_encode.o \
+	../../api/units/time_delta.o \
+	../../third_party/crc32c/src/src/crc32c.o \
+	../../third_party/crc32c/src/src/crc32c_portable.o \
+	./rx/reassembly_queue.o \
+	./rx/data_tracker.o \
+	./rx/interleaved_reassembly_streams.o \
+	./rx/traditional_reassembly_streams.o \
+	./testing/data_generator.o \
+	./tx/stream_scheduler.o \
+	./tx/retransmission_error_counter.o \
+	./tx/rr_send_queue.o \
+	./tx/retransmission_timeout.o \
+	./tx/retransmission_queue.o \
+	./tx/outstanding_data.o \
+	./timer/timer.o \
+	./timer/task_queue_timeout.o \
+	./packet/parameter/supported_extensions_parameter.o \
+	./packet/parameter/parameter.o \
+	./packet/parameter/ssn_tsn_reset_request_parameter.o \
+	./packet/parameter/state_cookie_parameter.o \
+	./packet/parameter/heartbeat_info_parameter.o \
+	./packet/parameter/outgoing_ssn_reset_request_parameter.o \
+	./packet/parameter/add_outgoing_streams_request_parameter.o \
+	./packet/parameter/add_incoming_streams_request_parameter.o \
+	./packet/parameter/reconfiguration_response_parameter.o \
+	./packet/parameter/forward_tsn_supported_parameter.o \
+	./packet/parameter/zero_checksum_acceptable_chunk_parameter.o \
+	./packet/parameter/incoming_ssn_reset_request_parameter.o \
+	./packet/error_cause/invalid_stream_identifier_cause.o \
+	./packet/error_cause/error_cause.o \
+	./packet/error_cause/unresolvable_address_cause.o \
+	./packet/error_cause/user_initiated_abort_cause.o \
+	./packet/error_cause/stale_cookie_error_cause.o \
+	./packet/error_cause/unrecognized_chunk_type_cause.o \
+	./packet/error_cause/out_of_resource_error_cause.o \
+	./packet/error_cause/protocol_violation_cause.o \
+	./packet/error_cause/cookie_received_while_shutting_down_cause.o \
+	./packet/error_cause/invalid_mandatory_parameter_cause.o \
+	./packet/error_cause/missing_mandatory_parameter_cause.o \
+	./packet/error_cause/no_user_data_cause.o \
+	./packet/error_cause/unrecognized_parameter_cause.o \
+	./packet/chunk/heartbeat_request_chunk.o \
+	./packet/chunk/init_chunk.o \
+	./packet/chunk/shutdown_chunk.o \
+	./packet/chunk/error_chunk.o \
+	./packet/chunk/idata_chunk.o \
+	./packet/chunk/data_chunk.o \
+	./packet/chunk/init_ack_chunk.o \
+	./packet/chunk/cookie_echo_chunk.o \
+	./packet/chunk/shutdown_complete_chunk.o \
+	./packet/chunk/shutdown_ack_chunk.o \
+	./packet/chunk/heartbeat_ack_chunk.o \
+	./packet/chunk/cookie_ack_chunk.o \
+	./packet/chunk/forward_tsn_chunk.o \
+	./packet/chunk/iforward_tsn_chunk.o \
+	./packet/chunk/reconfig_chunk.o \
+	./packet/chunk/chunk.o \
+	./packet/chunk/abort_chunk.o \
+	./packet/chunk/sack_chunk.o \
+	./packet/tlv_trait.o \
+	./packet/chunk_validators.o \
+	./packet/crc32c.o \
+	./packet/sctp_packet.o \
+	./fuzzers/dcsctp_fuzzers.o \
+	./public/dcsctp_handover_state.o \
+	./public/dcsctp_socket_factory.o \
+	./public/text_pcap_packet_observer.o \
+	./socket/transmission_control_block.o \
+	./socket/heartbeat_handler.o \
+	./socket/packet_sender.o \
+	./socket/callback_deferrer.o \
+	./socket/dcsctp_socket.o \
+	./socket/state_cookie.o \
+	./socket/stream_reset_handler.o \
+	./common/handover_testing.o
+OBJS += ./packet/error_cause/restart_of_an_association_with_new_address_cause.o
+
+libdcsctp.a: $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	$(RM) $(OBJS) libdcsctp.a

--- a/resources/checkout-webrtc.sh
+++ b/resources/checkout-webrtc.sh
@@ -18,6 +18,9 @@ REV=$3
 
 STARTDIR=$PWD
 
+if test "$(uname -m)" = "ppc64le"; then
+    exit 0
+fi
 if test -d "$DEPOT_TOOLS_DIR"; then
     if test \! -d "$DEPOT_TOOLS_DIR"/.git; then
         echo "ERROR: $DEPOT_TOOLS_DIR exists, but does not seem to be a Git repository"

--- a/resources/ubuntu-build-all.sh
+++ b/resources/ubuntu-build-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 PROJECT_DIR="$(realpath "$(dirname "$0")/../")"
 JAVA_VERSION=11
-ARCHS=(x86-64 arm64)
+ARCHS=(x86-64 arm64 ppc64le)
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <DEPOT_TOOLS_DIR> <WEBRTC_DIR>"


### PR DESCRIPTION
This change adds cross-compilation support for `ppc64le`, as discussed in #6.  Can you please send it through a `dcsctp4j` continuous integration run and let me know the results?  You will probably have to adapt the CI setup script to install `g++-powerpc64le-linux-gnu`.