### PR TITLE
Add ppc64le cross-compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Prerequisites:
 - Maven
 - CMake
 - Git
-- APT packages `build-essentials`, `g++-aarch64-linux-gnu` and their dependencies
+- APT packages `build-essential`, `g++-aarch64-linux-gnu`, `g++-powerpc64le-linux-gnu` and their dependencies
 
 * Clone the project
 * Update the SimpleJNI subproject with

--- a/cmake/ppc64el-linux-gnu.cmake
+++ b/cmake/ppc64el-linux-gnu.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_PROCESSOR "ppc64le")
+
+set(CMAKE_C_COMPILER /usr/bin/powerpc64le-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/powerpc64le-linux-gnu-g++)

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -1,0 +1,92 @@
+# Minimal build steps that produce libdcsctp.a
+# Copyright (C) 2025
+# Author: Thomas Fitzsimmons <fitzsim@fitzsim.org>
+# Version: 1
+# SPDX-License-Identifier: Apache-2.0
+# "gn" has no support for ppc64le.  This Makefile can be used in place of "gn"
+# and "ninja" to build libdcsctp.a on non-"gn" architectures.  The Makefile was
+# written from scratch starting from the assumption that all non-test net/dcsctp
+# .cc files were needed by libdcsctp4j.so.  Runtime testing of Jitsi confirms
+# that the resulting libdcsctp.a satisfies libdcsctp4j.so's needs on ppc64le.
+S := $(VPATH)
+DEBUG ?= -O2
+# Add GCC-compatible flags extracted from "ninja -v" output for x86-64 target.
+CXXFLAGS += -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1
+CXXFLAGS += -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2
+CXXFLAGS += -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE
+CXXFLAGS += -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE
+CXXFLAGS += -D_GLIBCXX_ASSERTIONS=1
+CXXFLAGS += -DNDEBUG -DNVALGRIND
+CXXFLAGS += -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DWEBRTC_ENABLE_PROTOBUF=1
+CXXFLAGS += -DWEBRTC_STRICT_FIELD_TRIALS=0
+CXXFLAGS += -DWEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE -DRTC_ENABLE_VP9
+CXXFLAGS += -DRTC_DAV1D_IN_INTERNAL_DECODER_FACTORY -DWEBRTC_HAVE_SCTP
+CXXFLAGS += -DWEBRTC_ENABLE_LIBEVENT -DWEBRTC_LIBRARY_IMPL -DWEBRTC_ENABLE_AVX2
+CXXFLAGS += -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=1 -DWEBRTC_POSIX
+CXXFLAGS += -DWEBRTC_LINUX -DABSL_ALLOCATOR_NOTHROW=1 -Wall -Wextra
+CXXFLAGS += -Wimplicit-fallthrough -Wextra-semi -Wno-missing-field-initializers
+CXXFLAGS += -Wno-unused-parameter -Wno-psabi -Wno-cast-function-type
+CXXFLAGS += -Wno-invalid-offsetof -Wshadow -Werror
+CXXFLAGS += -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing
+CXXFLAGS += -fstack-protector -funwind-tables -fPIC -pthread
+CXXFLAGS += -fmerge-all-constants -ffp-contract=off -m64
+CXXFLAGS += -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__=
+CXXFLAGS += -D__TIMESTAMP__= -no-canonical-prefixes
+CXXFLAGS += -ftrivial-auto-var-init=pattern $(DEBUG) -fdata-sections
+CXXFLAGS += -ffunction-sections -fno-math-errno -fno-omit-frame-pointer
+CXXFLAGS += -gdwarf-4 -g2 -ggnu-pubnames -fvisibility=hidden -Wno-shadow
+CXXFLAGS += -Wctad-maybe-unsupported -Wundef -std=c++17 -Wno-trigraphs
+CXXFLAGS += -fno-exceptions -fno-rtti
+CXXFLAGS += -fvisibility-inlines-hidden -Wnon-virtual-dtor -Woverloaded-virtual
+# Silence GCC 12 warnings.
+CXXFLAGS += -Wno-return-type -Wno-overloaded-virtual -Wno-comment -Wno-undef
+CXXFLAGS += -Wno-redundant-move
+# Add include paths to fix compilation errors due to missing headers.
+CXXFLAGS += -I$(S)
+CXXFLAGS += -I$(S)/third_party/abseil-cpp
+CXXFLAGS += -I$(S)/third_party/crc32c/config
+CXXFLAGS += -I$(S)/third_party/crc32c/src/include
+# Assume all non-test .cc files under net/dcsctp are needed by libdcsctp4j.so.
+# "gn/ninja" includes 37 extra objects but they are not needed by
+# libdcsctp4j.so.
+TESTS = $(wildcard $(S)/net/dcsctp/*/*_test*.cc $(S)/net/dcsctp/*/*/*_test*.cc)
+SOURCES = $(wildcard $(S)/net/dcsctp/*/*.cc $(S)/net/dcsctp/*/*/*.cc)
+OBJECTS = $(patsubst %.cc,%.o,$(filter-out $(TESTS),$(SOURCES)))
+# Assume all source files are in subdirectories and subsubdirectories of
+# net/dcsctp.
+DIRS = $(wildcard $(S)/*/ $(S)/*/*/ $(S)/*/*/*/ $(S)/*/*/*/*/ $(S)/*/*/*/*/*/)
+# Add other objects required to fix libdcsctp4j.so errors; first compilation
+# errors, then undefined symbol errors reported at runtime by the dynamic
+# linker.
+OBJECTS += $(S)/api/units/time_delta.o
+OBJECTS += $(S)/rtc_base/checks.o
+OBJECTS += $(S)/rtc_base/logging.o
+OBJECTS += $(S)/rtc_base/platform_thread_types.o
+OBJECTS += $(S)/rtc_base/string_encode.o
+OBJECTS += $(S)/rtc_base/string_utils.o
+OBJECTS += $(S)/rtc_base/strings/string_builder.o
+OBJECTS += $(S)/rtc_base/strings/string_format.o
+OBJECTS += $(S)/rtc_base/system_time.o
+OBJECTS += $(S)/rtc_base/time_utils.o
+OBJECTS += $(S)/third_party/abseil-cpp/absl/base/internal/raw_logging.o
+OBJECTS += $(S)/third_party/abseil-cpp/absl/types/bad_variant_access.o
+OBJECTS += $(S)/third_party/crc32c/src/src/crc32c.o
+OBJECTS += $(S)/third_party/crc32c/src/src/crc32c_portable.o
+# Keep built object paths separate from source code paths.
+ifeq ($(strip $(OBJDIR)),)
+$(error "Set OBJDIR to absolute path in which to store output objects")
+endif
+OBJECTS := $(addprefix $(OBJDIR)/,$(OBJECTS))
+OBJDIRS := $(addprefix $(OBJDIR)/,$(DIRS))
+ifneq ($(strip $(VERBOSE)),1)
+SILENT := @
+endif
+$(OBJDIR)/%.o: %.cc
+	@echo CXX $@
+	$(SILENT)$(CXX) $(CXXFLAGS) -c $< -o $@
+$(OBJDIR)/libdcsctp.a: $(OBJECTS)
+	@echo AR $@
+	$(SILENT)$(AR) $(ARFLAGS) $@ $^
+$(OBJECTS): | $(OBJDIRS)
+$(OBJDIRS):
+	@mkdir -p $(OBJDIRS)

--- a/resources/ubuntu-build-all.sh
+++ b/resources/ubuntu-build-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 PROJECT_DIR="$(realpath "$(dirname "$0")/../")"
 JAVA_VERSION=11
-ARCHS=(x86-64 arm64)
+ARCHS=(x86-64 arm64 ppc64le)
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <DEPOT_TOOLS_DIR> <WEBRTC_DIR>"
@@ -39,5 +39,8 @@ mvn compile # Build SimpleJNI jnigen headers
 "$PROJECT_DIR/resources/checkout-webrtc.sh" "$DEPOT_TOOLS_DIR" "$WEBRTC_DIR" "$WEBRTC_REVISION"
 
 for ARCH in "${ARCHS[@]}"; do
-    "$PROJECT_DIR/resources/ubuntu-build.sh" "$JAVA_HOME" "$DEPOT_TOOLS_DIR" "$WEBRTC_DIR" "$ARCH"
+    if test "$ARCH" = "ppc64le"; then
+        MAKEFILE_ARGUMENT=BUILD_DCSCTP_WITH_MAKEFILE
+    fi
+    "$PROJECT_DIR/resources/ubuntu-build.sh" "$JAVA_HOME" "$DEPOT_TOOLS_DIR" "$WEBRTC_DIR" "$ARCH" "$MAKEFILE_ARGUMENT"
 done

--- a/resources/ubuntu-build.sh
+++ b/resources/ubuntu-build.sh
@@ -58,8 +58,8 @@ PATH=$PATH:$DEPOT_TOOLS_DIR
 startdir=$PWD
 
 cd $WEBRTC_DIR
-./build/linux/sysroot_scripts/install-sysroot.py --arch=$GN_ARCH
 rm -rf $WEBRTC_BUILD
+./build/linux/sysroot_scripts/install-sysroot.py --arch=$GN_ARCH
 gn gen $WEBRTC_BUILD --args="use_custom_libcxx=false target_cpu=\"$GN_ARCH\" is_debug=false symbol_level=2"
 ninja -C $WEBRTC_BUILD dcsctp
 

--- a/resources/ubuntu-build.sh
+++ b/resources/ubuntu-build.sh
@@ -39,6 +39,12 @@ if [ $DEBARCH != $NATIVEDEBARCH -a -f "cmake/$DEBARCH-linux-gnu.cmake" ]; then
     TOOLCHAIN_FILE="cmake/$DEBARCH-linux-gnu.cmake"
 fi
 
+NCPU=$(nproc)
+if [ -n "$NCPU" -a "$NCPU" -gt 1 ]
+then
+    MAKE_ARGS="-j $NCPU"
+fi
+
 if test \! -d $WEBRTC_DIR/.git -a -r $WEBRTC_DIR/.gclient -a -d $WEBRTC_DIR/src/.git; then
     # They specified the WebRTC gclient directory, not the src checkout subdirectory
     WEBRTC_DIR=$WEBRTC_DIR/src
@@ -58,12 +64,6 @@ gn gen $WEBRTC_BUILD --args="use_custom_libcxx=false target_cpu=\"$GN_ARCH\" is_
 ninja -C $WEBRTC_BUILD dcsctp
 
 cd $startdir
-
-NCPU=$(nproc)
-if [ -n "$NCPU" -a "$NCPU" -gt 1 ]
-then
-    MAKE_ARGS="-j $NCPU"
-fi
 
 if [ -n "$MAKE_ARGS" ]
 then

--- a/resources/ubuntu-build.sh
+++ b/resources/ubuntu-build.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-if [ "$#" -ne 4 ]; then
-    echo "Usage: $0 <JAVA_HOME> <DEPOT_TOOLS_DIR> <WEBRTC_DIR> <ARCH>"
+if [ "$#" -lt 4 -o "$#" -gt 5 ]; then
+    echo "Usage: $0 <JAVA_HOME> <DEPOT_TOOLS_DIR> <WEBRTC_DIR> <ARCH> [USE_MAKEFILE]"
     echo "  JAVA_HOME: Path to Java installation"
     echo "  DEPOT_TOOLS_DIR: Directory containing Google depot tools"
     echo "  WEBRTC_DIR: Directory containing WebRTC source"
-    echo "  ARCH: Architecture to build for (x86_64 or arm64)"
+    echo "  ARCH: Architecture to build for (x86_64, arm64, or ppc64le)"
+    echo "  USE_MAKEFILE: \"BUILD_DCSCTP_WITH_MAKEFILE\" => Use non-gn/ninja arch Makefile"
     exit 1
 fi
 
@@ -15,6 +16,7 @@ JAVA_HOME=$1
 DEPOT_TOOLS_DIR=$2
 WEBRTC_DIR=$3
 ARCH=$4
+USE_MAKEFILE=$5
 
 case $ARCH in
     "x86-64"|"x86_64"|"amd64"|"x64")
@@ -26,6 +28,12 @@ case $ARCH in
         JNAARCH=aarch64
         DEBARCH=arm64
         GN_ARCH=arm64
+        ;;
+    "ppc64le")
+        JNAARCH=ppc64le
+        DEBARCH=ppc64el
+        GN_ARCH=ppc64le
+        GNU_ARCH=powerpc64le
         ;;
     *)
 	echo "ERROR: Unsupported arch $ARCH"
@@ -59,9 +67,17 @@ startdir=$PWD
 
 cd $WEBRTC_DIR
 rm -rf $WEBRTC_BUILD
-./build/linux/sysroot_scripts/install-sysroot.py --arch=$GN_ARCH
-gn gen $WEBRTC_BUILD --args="use_custom_libcxx=false target_cpu=\"$GN_ARCH\" is_debug=false symbol_level=2"
-ninja -C $WEBRTC_BUILD dcsctp
+if test "$USE_MAKEFILE" != "BUILD_DCSCTP_WITH_MAKEFILE"; then
+    ./build/linux/sysroot_scripts/install-sysroot.py --arch=$GN_ARCH
+    gn gen $WEBRTC_BUILD --args="use_custom_libcxx=false target_cpu=\"$GN_ARCH\" is_debug=false symbol_level=2"
+    ninja -C $WEBRTC_BUILD dcsctp
+else
+    make $MAKE_ARGS -C $startdir/resources \
+        VPATH="$WEBRTC_DIR" \
+        OBJDIR="$WEBRTC_OBJ/obj" \
+        CXX=${GNU_ARCH}-linux-gnu-g++ \
+        AR=${GNU_ARCH}-linux-gnu-ar
+fi
 
 cd $startdir
 


### PR DESCRIPTION
I tested:
```
export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
resources/ubuntu-build-all.sh ~/depot_tools ~/WebRTC
```
on `x86-64` `Debian 12`.  `x86-64` and `aarch64` libraries built as before, and the `ppc64le` cross-compilation succeeded.  I tested the new library:
```
dcsctp4j/src/main/resources/linux-ppc64le/./libdcsctp4j.so
```
on my `Debian 12` `ppc64le` `Jitsi` installation and it worked when I initiated a two-party meeting:
```
JVB 2025-02-10 22:02:53.029 INFO: [50] DcSctp4j.<clinit>#38: DcSctp4j lib loaded
```
I made `ninja` verbose so that its compiler arguments are available in continuous integration logs for comparison with those specified by the new `Makefile`.

The other two `ubuntu-build.sh` changes reorder some lines in preparation for the addition of the `ppc64le` logic.